### PR TITLE
fix(Dockerfile): use patched alpine baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.2
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/


### PR DESCRIPTION
Bump alpine to 3.14.2 to get rid the vulnerabilities in 3.14.0, except CVE-2021-32760  in `usr/local/bin/trivy (gobinary)` (ofc)

This fixes #1240